### PR TITLE
Migrate player inventory from String to NBT

### DIFF
--- a/src/main/java/com/loot4everyone/PlayerData.java
+++ b/src/main/java/com/loot4everyone/PlayerData.java
@@ -1,12 +1,11 @@
 package com.loot4everyone;
 
-import net.minecraft.inventory.Inventory;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemConvertible;
 import net.minecraft.item.ItemStack;
-import net.minecraft.registry.Registry;
-import net.minecraft.registry.RegistryKey;
-import net.minecraft.registry.RegistryKeys;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtList;
+import net.minecraft.registry.Registries;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
@@ -25,26 +24,6 @@ public class PlayerData {
         inventory.put(pos, stacks);
     }
 
-    public void setInventory(HashMap<BlockPos, List<ItemStack>> inventory){
-        this.inventory = inventory;
-    }
-
-    public String inventoryToString() {
-        if (inventory == null) {
-            return "";
-        }
-        StringJoiner joiner = new StringJoiner(";");
-        for (Map.Entry<BlockPos, List<ItemStack>> entry : inventory.entrySet()) {
-            String pos = entry.getKey().getX() + "," + entry.getKey().getY() + "," + entry.getKey().getZ();
-            StringJoiner itemJoiner = new StringJoiner(",");
-            for (ItemStack stack : entry.getValue()) {
-                itemJoiner.add(Item.getRawId(stack.getItem()) + "%" + stack.getCount());
-            }
-            joiner.add(pos + "=" + itemJoiner);
-        }
-        return joiner.toString();
-    }
-
     public void stringToInventory(String data) {
         if (data == null || data.isEmpty()) return;
         inventory.clear();
@@ -60,6 +39,69 @@ public class PlayerData {
                 stacks.add(itemStack);
             }
             inventory.put(pos, stacks);
+        }
+    }
+
+    public NbtList inventoryToNbt() {
+        NbtList inventoryEntriesTag = new NbtList();
+
+        for (Map.Entry<BlockPos, List<ItemStack>> positionEntry : inventory.entrySet()) {
+            BlockPos chestPosition = positionEntry.getKey();
+            List<ItemStack> itemStacksAtPosition = positionEntry.getValue();
+            if (itemStacksAtPosition == null || itemStacksAtPosition.isEmpty()) continue;
+
+            NbtCompound inventoryTag = new NbtCompound();
+            inventoryTag.putLong("position", chestPosition.asLong());
+
+            NbtList stackList = new NbtList();
+            for (ItemStack itemStack : itemStacksAtPosition) {
+                if (itemStack == null || itemStack.isEmpty()) continue;
+
+                NbtCompound stackTag = new NbtCompound();
+                Identifier itemIdentifier = Registries.ITEM.getId(itemStack.getItem());
+                int stackCount = itemStack.getCount();
+
+                stackTag.putString("id", itemIdentifier.toString());
+                stackTag.putInt("count", stackCount);
+                stackList.add(stackTag);
+            }
+
+            if (!stackList.isEmpty()) {
+                inventoryTag.put("items", stackList);
+                inventoryEntriesTag.add(inventoryTag);
+            }
+        }
+
+        return inventoryEntriesTag;
+    }
+
+    public void inventoryFromNbt(NbtList inventoryEntriesTag) {
+        this.inventory.clear();
+
+        for (int entryIndex = 0; entryIndex < inventoryEntriesTag.size(); entryIndex++) {
+            NbtCompound inventoryTag = inventoryEntriesTag.getCompound(entryIndex);
+
+            long blockPosition = inventoryTag.getLong("position");
+            BlockPos chestPosition = BlockPos.fromLong(blockPosition);
+
+            NbtList stackList = inventoryTag.getList("items", NbtElement.COMPOUND_TYPE);
+            List<ItemStack> stacks = new ArrayList<>(stackList.size());
+
+            for (int stackIndex = 0; stackIndex < stackList.size(); stackIndex++) {
+                NbtCompound stackTag = stackList.getCompound(stackIndex);
+
+                String itemId = stackTag.getString("id");
+                Identifier itemIdentifier = Identifier.tryParse(itemId);
+                int stackCount = stackTag.getInt("count");
+                if (itemIdentifier == null || stackCount <= 0) continue;
+
+                Item item = Registries.ITEM.get(itemIdentifier);
+                stacks.add(new ItemStack(item, stackCount));
+            }
+
+            if (!stacks.isEmpty()) {
+                this.inventory.put(chestPosition, stacks);
+            }
         }
     }
 

--- a/src/main/java/com/loot4everyone/StateSaverAndLoader.java
+++ b/src/main/java/com/loot4everyone/StateSaverAndLoader.java
@@ -5,9 +5,9 @@ import net.minecraft.block.ChestBlock;
 import net.minecraft.block.entity.ChestBlockEntity;
 import net.minecraft.block.enums.ChestType;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.decoration.ItemFrameEntity;
-import net.minecraft.item.Item;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtList;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
@@ -32,7 +32,7 @@ public class StateSaverAndLoader extends PersistentState {
         NbtCompound playersNbt = new NbtCompound();
         players.forEach(((uuid, playerData) -> {
             NbtCompound playerNbt = new NbtCompound();
-            playerNbt.putString("inventory",playerData.inventoryToString());
+            playerNbt.put("inventory", playerData.inventoryToNbt());
             playersNbt.put(uuid.toString(),playerNbt);
         }));
         nbt.put("players", playersNbt);
@@ -58,20 +58,31 @@ public class StateSaverAndLoader extends PersistentState {
 
     public static StateSaverAndLoader createFromNbt(NbtCompound tag, RegistryWrapper.WrapperLookup registryLookup) {
         StateSaverAndLoader state = new StateSaverAndLoader();
+        boolean migratedFromLegacy = false;
 
-        NbtCompound playersNbt = tag.getCompound("players");
-        playersNbt.getKeys().forEach(key -> {
+        NbtCompound playersTag = tag.getCompound("players");
+        for (String playerUuid : playersTag.getKeys()) {
+            NbtCompound playerTag = playersTag.getCompound(playerUuid);
             PlayerData playerData = new PlayerData();
-            playerData.stringToInventory(playersNbt.getCompound(key).getString("inventory"));
-            UUID uuid = UUID.fromString(key);
-            state.players.put(uuid, playerData);
-        });
+
+            if (playerTag.contains("inventory", NbtElement.LIST_TYPE)) {
+                NbtList inventoryEntries = playerTag.getList("inventory", NbtElement.COMPOUND_TYPE);
+                playerData.inventoryFromNbt(inventoryEntries);
+            } else if (playerTag.contains("inventory", NbtElement.STRING_TYPE)) {
+                String legacyInventory = playerTag.getString("inventory");
+                if (legacyInventory != null && !legacyInventory.isEmpty()) {
+                    playerData.stringToInventory(legacyInventory);
+                    migratedFromLegacy = true;
+                }
+            }
+            state.players.put(UUID.fromString(playerUuid), playerData);
+        }
         NbtCompound chestsNbt = tag.getCompound("chests");
         chestsNbt.getKeys().forEach(key -> {
             ChestData chestData = new ChestData();
             chestData.stringToChestData(chestsNbt.getCompound(key).getString("chestdata"));
             String[] posParts = key.split(",");
-            BlockPos pos = new BlockPos(Integer.parseInt(posParts[0]), Integer.parseInt(posParts[1]), Integer.parseInt(posParts[2]));
+            BlockPos pos = new BlockPos(Integer.parseInt(posParts[0]),Integer.parseInt(posParts[1]),Integer.parseInt(posParts[2]));
             state.chests.put(pos, chestData);
         });
         NbtCompound itemframesNbt = tag.getCompound("itemframes");
@@ -85,6 +96,8 @@ public class StateSaverAndLoader extends PersistentState {
         if (settingsString != null && !settingsString.isEmpty()) {
             state.settings.setSettings(settingsString);
         }
+
+        if (migratedFromLegacy) state.markDirty();
         return state;
     }
 

--- a/src/main/java/com/loot4everyone/mixin/ChestBlockEntityMixin.java
+++ b/src/main/java/com/loot4everyone/mixin/ChestBlockEntityMixin.java
@@ -1,7 +1,6 @@
 package com.loot4everyone.mixin;
 
 import com.loot4everyone.*;
-import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.ChestBlock;
 import net.minecraft.block.entity.BlockEntity;
@@ -9,14 +8,8 @@ import net.minecraft.block.entity.ChestBlockEntity;
 import net.minecraft.block.enums.ChestType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
-import net.minecraft.nbt.NbtCompound;
-import net.minecraft.registry.RegistryWrapper;
-import net.minecraft.util.ActionResult;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.BlockView;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -35,42 +28,32 @@ public abstract class ChestBlockEntityMixin {
         BlockState blockState = chest.getCachedState();
         if (blockPos != null) {
             if (blockState.get(ChestBlock.CHEST_TYPE) == ChestType.SINGLE) {
-                if (StateSaverAndLoader.isBarrelStatePresentInPlayerState(Loot4Everyone.server, player, blockPos)) {
-                    PlayerData playerData = StateSaverAndLoader.getPlayerState(Loot4Everyone.server, player);
-                    List<ItemStack> inventory = playerData.getInventory().get(blockPos);
-                    for (int i = 0; i < inventory.size(); i++) {
-                        chest.setStack(i, inventory.get(i));
-                    }
+                List<ItemStack> inventory = StateSaverAndLoader.getPlayerState(Loot4Everyone.server, player).getInventory().get(blockPos);
+                if (inventory != null) {
+                    int inventorySize = Math.min(chest.size(), inventory.size());
+                    for (int i = 0; i < inventorySize; i++) chest.setStack(i, inventory.get(i));
                 } else {
-                    ChestData chestData = StateSaverAndLoader.getChestState(Loot4Everyone.server, blockPos);
-                    chest.setLootTable(chestData.getLootTable(), chestData.getLootTableSeed());
+                    ChestData data = StateSaverAndLoader.getChestState(Loot4Everyone.server, blockPos);
+                    chest.setLootTable(data.getLootTable(), data.getLootTableSeed());
                     chest.generateLoot(player);
                 }
             }
             else if (blockState.get(ChestBlock.CHEST_TYPE) == ChestType.LEFT) {
                 BlockPos rightPos = blockPos.offset(blockState.get(ChestBlock.FACING).rotateYClockwise());
+                List<ItemStack> inventory = StateSaverAndLoader.getPlayerState(Loot4Everyone.server, player).getInventory().get(blockPos);
 
-                if (StateSaverAndLoader.isBarrelStatePresentInPlayerState(Loot4Everyone.server, player, blockPos)) {
-                    // Load both chests from player state
-                    PlayerData playerData = StateSaverAndLoader.getPlayerState(Loot4Everyone.server, player);
-                    List<ItemStack> inventory = playerData.getInventory().get(blockPos);
+                if (inventory != null) {
+                    int inventorySize = Math.min(27, inventory.size());
+                    for (int i = 0; i < inventorySize; i++) chest.setStack(i, inventory.get(i));
 
-                    // Left chest
-                    for (int i = 0; i < 27; i++) { // First half for left chest
-                        chest.setStack(i, inventory.get(i));
-                    }
-
-                    // Right chest
                     BlockEntity rightEntity = player.getWorld().getBlockEntity(rightPos);
                     if (rightEntity instanceof ChestBlockEntity rightChest) {
-                        for (int i = 27; i < 54; i++) { // Second half for right chest
-                            rightChest.setStack(i - 27, inventory.get(i));
-                        }
+                        int rightSize = Math.min(54, inventory.size());
+                        for (int i = 27; i < rightSize; i++) rightChest.setStack(i - 27, inventory.get(i));
                     }
                 } else {
-                    // Generate loot only for left chest
-                    ChestData chestData = StateSaverAndLoader.getChestState(Loot4Everyone.server, blockPos);
-                    chest.setLootTable(chestData.getLootTable(), chestData.getLootTableSeed());
+                    ChestData data = StateSaverAndLoader.getChestState(Loot4Everyone.server, blockPos);
+                    chest.setLootTable(data.getLootTable(), data.getLootTableSeed());
                     chest.generateLoot(player);
                 }
             }


### PR DESCRIPTION
# Fix save lag by migrating `inventory` from String to NBT.

The mod stored all per-player chest contents as one large String. As data grew, that string exceeded Java's `writeUTF` 65,535-byte limit, causing lag on save. For example: `java.io.UTFDataFormatException: encoded string ... too long: 65600 bytes`

## What Changed
- Write path: `StateSaverAndLoader.writeNbt` now writes `inventory` as an `NBTList<Compound>` under the same key.
- Read path and migrations: `StateSaverAndLoader.createFromNbt` detects the type of `inventory`:
  - If `LIST` -> read new format.
  - If `STRING` -> parse old format, load into memory and mark it so that the next save writes it to the new format.

## Verify
1. Start server with this build and open at least one per-player chest (to ensure the state is loaded).
2. Run `/save-all`.
3. Inspect the save: `loot4everyone.dat/players/<uuid>/inventory` should be a `List` of items (contains `id` and `count`)
 